### PR TITLE
Remove automatic column fitting to preserve preset widths

### DIFF
--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -636,7 +636,6 @@ Public Sub BuildSnapshot()
     
 ' Format overall sheet (no .Select calls)
 With wsSnap
-    .Columns("A:AZ").EntireColumn.AutoFit
     .Columns(5).Hidden = True   ' Code column (E) hidden
 End With
 
@@ -1447,9 +1446,6 @@ Private Sub EnsureUsaliMap()
         End If
         outRow = outRow + 1
     Next i
-    
-    wsMap.Columns("A:C").AutoFit
-    wsMap.Columns("E:F").AutoFit
 
     ' STR mapping
     Dim strPairs As Variant


### PR DESCRIPTION
## Summary
- Stop automatically auto-fitting snapshot columns so preset widths remain intact.
- Remove column auto-fit from USALI mapping setup to respect predefined column sizes.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bb5659288323a408163511c62563