### PR TITLE
Add PDF export for snapshot report and input button

### DIFF
--- a/PdfReportModule.bas
+++ b/PdfReportModule.bas
@@ -1,0 +1,81 @@
+Option Explicit
+
+Private Const SH_SNAP As String = "Snapshot"
+Private Const LOGO_SHAPE As String = "Logo"
+Private Const FOOTER_TEXT As String = "Confidential - For internal use only"
+
+' Main entry point called by button on Input sheet
+Public Sub BuildSnapshotReportPDF()
+    ' Ensure snapshot content is up to date
+    BuildSnapshot
+
+    Dim ws As Worksheet
+    Set ws = Worksheets(SH_SNAP)
+
+    ApplyReportPageSetup ws
+    ApplyTablePageBreaks ws
+
+    Dim pdfPath As String
+    pdfPath = ThisWorkbook.Path & Application.PathSeparator & _
+              "SnapshotReport_" & Format(Now, "yyyymmdd_hhnn") & ".pdf"
+    ws.ExportAsFixedFormat Type:=xlTypePDF, Filename:=pdfPath, _
+                            Quality:=xlQualityStandard, _
+                            IncludeDocProperties:=True, _
+                            IgnorePrintAreas:=False, OpenAfterPublish:=False
+    MsgBox "Snapshot report exported to:" & vbCrLf & pdfPath, vbInformation
+End Sub
+
+' Configure header/footer, orientation, paper size, logo etc.
+Private Sub ApplyReportPageSetup(ws As Worksheet)
+    With ws.PageSetup
+        .Orientation = xlLandscape
+        .PaperSize = xlPaperTabloid
+        .Zoom = False
+        .FitToPagesWide = 1
+        .FitToPagesTall = False
+        .TopMargin = Application.InchesToPoints(0.5)
+        .BottomMargin = Application.InchesToPoints(0.5)
+        .LeftMargin = Application.InchesToPoints(0.5)
+        .RightMargin = Application.InchesToPoints(0.5)
+        .CenterFooter = FOOTER_TEXT
+        .PrintTitleRows = "$1:$3"
+        InsertLogo .Parent
+    End With
+End Sub
+
+' Insert logo on every page via header picture
+Private Sub InsertLogo(ws As Worksheet)
+    On Error GoTo NoLogo
+    Dim shp As Shape
+    Set shp = ws.Shapes(LOGO_SHAPE)
+    Dim tmpPath As String
+    tmpPath = Environ("TEMP") & Application.PathSeparator & "snapLogo.png"
+    shp.Export Filename:=tmpPath, FilterName:="PNG"
+    With ws.PageSetup
+        .LeftHeaderPicture.Filename = tmpPath
+        .LeftHeader = "&G"
+    End With
+    Kill tmpPath
+    Exit Sub
+NoLogo:
+    ' Silently ignore if logo not found
+End Sub
+
+' Ensure page breaks occur before each major table so headers repeat cleanly
+Private Sub ApplyTablePageBreaks(ws As Worksheet)
+    Dim lastRow As Long
+    lastRow = ws.Cells(ws.Rows.Count, 2).End(xlUp).Row
+    Dim r As Long, firstTable As Boolean
+    firstTable = False
+    For r = 4 To lastRow
+        Select Case UCase$(Trim$(ws.Cells(r, 2).Value))
+            Case "HOTEL", "MANAGER", "MARKET"
+                If firstTable Then
+                    ws.HPageBreaks.Add Before:=ws.Rows(r)
+                Else
+                    firstTable = True
+                End If
+        End Select
+    Next r
+End Sub
+

--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -1647,8 +1647,8 @@ Private Sub EnsureInputSheet()
         ' Sheet already exists: do NOT recreate or clear.
         Set ws = Worksheets(SH_INPUT)
 
-        ' Ensure the single build button exists and is wired up
-       
+        ' Ensure the snapshot build button exists and is wired up
+
         On Error Resume Next
         Set btn = ws.Shapes("btnBuildSnapshot")
         On Error GoTo 0
@@ -1660,13 +1660,34 @@ Private Sub EnsureInputSheet()
                         Left:=ws.Range("D1").Left, _
                         Top:=ws.Range("D1").Top, _
                         Width:=140, Height:=28)
-            btn.name = "btnBuildSnapshot"
+            btn.Name = "btnBuildSnapshot"
         End If
 
         ' Wire caption + macro every time (idempotent)
         With btn
             .OnAction = "BuildFormatRun"
             .TextFrame.Characters.Text = "Build Snapshot"
+            .TextFrame.Characters.Font.Size = 11
+            .Placement = xlMove
+        End With
+
+        ' Ensure the PDF export button exists and is wired up
+        On Error Resume Next
+        Set btn = ws.Shapes("btnExportSnapshotPDF")
+        On Error GoTo 0
+
+        If btn Is Nothing Then
+            Set btn = ws.Shapes.AddFormControl( _
+                        Type:=xlButtonControl, _
+                        Left:=ws.Range("D2").Left, _
+                        Top:=ws.Range("D2").Top, _
+                        Width:=140, Height:=28)
+            btn.Name = "btnExportSnapshotPDF"
+        End If
+
+        With btn
+            .OnAction = "BuildSnapshotReportPDF"
+            .TextFrame.Characters.Text = "Export Snapshot PDF"
             .TextFrame.Characters.Font.Size = 11
             .Placement = xlMove
         End With
@@ -1701,16 +1722,30 @@ Private Sub EnsureInputSheet()
         .Range("A1:A2").Font.Bold = True
 
         ' Create the build button ONCE as a Shape Form Control
-        
+
         Set btn = .Shapes.AddFormControl( _
                     Type:=xlButtonControl, _
                     Left:=.Range("D1").Left, _
                     Top:=.Range("D1").Top, _
                     Width:=140, Height:=28)
         With btn
-            .name = "btnBuildSnapshot"
+            .Name = "btnBuildSnapshot"
             .OnAction = "BuildFormatRun"
             .TextFrame.Characters.Text = "Build Snapshot"
+            .TextFrame.Characters.Font.Size = 11
+            .Placement = xlMove
+        End With
+
+        ' Second button to export PDF report
+        Set btn = .Shapes.AddFormControl( _
+                    Type:=xlButtonControl, _
+                    Left:=.Range("D2").Left, _
+                    Top:=.Range("D2").Top, _
+                    Width:=140, Height:=28)
+        With btn
+            .Name = "btnExportSnapshotPDF"
+            .OnAction = "BuildSnapshotReportPDF"
+            .TextFrame.Characters.Text = "Export Snapshot PDF"
             .TextFrame.Characters.Font.Size = 11
             .Placement = xlMove
         End With


### PR DESCRIPTION
## Summary
- add `BuildSnapshotReportPDF` module to create an 11x17 landscape, multi‑page PDF with repeated headers, disclaimer footer and logo
- automatically insert page breaks between Snapshot and STR tables and include logo via header picture
- update Input sheet setup to create a second "Export Snapshot PDF" button wired to the new macro

## Testing
- `rg -n "test" -i` (no test suite found)


------
https://chatgpt.com/codex/tasks/task_e_68a8bf8e52d48323ada3c73181b93b90