### PR TITLE
Refine snapshot PDF generation

### DIFF
--- a/PdfReportModule.bas
+++ b/PdfReportModule.bas
@@ -8,12 +8,18 @@ Private Const FOOTER_TEXT As String = "Confidential - For internal use only"
 Public Sub BuildSnapshotReportPDF()
     ' Ensure snapshot content is up to date
     BuildSnapshot
+    ' allow all calculations to complete before exporting
+    Application.Calculate
+    DoEvents
 
     Dim ws As Worksheet
     Set ws = Worksheets(SH_SNAP)
 
-    ApplyReportPageSetup ws
+    ' Apply page setup and capture logo path for later cleanup
+    Dim logoPath As String
+    logoPath = ApplyReportPageSetup(ws)
     ApplyTablePageBreaks ws
+    DoEvents
 
     Dim pdfPath As String
     pdfPath = ThisWorkbook.Path & Application.PathSeparator & _
@@ -22,11 +28,13 @@ Public Sub BuildSnapshotReportPDF()
                             Quality:=xlQualityStandard, _
                             IncludeDocProperties:=True, _
                             IgnorePrintAreas:=False, OpenAfterPublish:=False
+    ' clean up temporary logo file
+    If Len(logoPath) > 0 Then On Error Resume Next: Kill logoPath: On Error GoTo 0
     MsgBox "Snapshot report exported to:" & vbCrLf & pdfPath, vbInformation
 End Sub
 
 ' Configure header/footer, orientation, paper size, logo etc.
-Private Sub ApplyReportPageSetup(ws As Worksheet)
+Private Function ApplyReportPageSetup(ws As Worksheet) As String
     With ws.PageSetup
         .Orientation = xlLandscape
         .PaperSize = xlPaperTabloid
@@ -39,12 +47,12 @@ Private Sub ApplyReportPageSetup(ws As Worksheet)
         .RightMargin = Application.InchesToPoints(0.5)
         .CenterFooter = FOOTER_TEXT
         .PrintTitleRows = "$1:$3"
-        InsertLogo .Parent
+        ApplyReportPageSetup = InsertLogo(.Parent)
     End With
-End Sub
+End Function
 
 ' Insert logo on every page via header picture
-Private Sub InsertLogo(ws As Worksheet)
+Private Function InsertLogo(ws As Worksheet) As String
     On Error GoTo NoLogo
     Dim shp As Shape
     Set shp = ws.Shapes(LOGO_SHAPE)
@@ -55,25 +63,29 @@ Private Sub InsertLogo(ws As Worksheet)
         .LeftHeaderPicture.Filename = tmpPath
         .LeftHeader = "&G"
     End With
-    Kill tmpPath
-    Exit Sub
+    InsertLogo = tmpPath
+    Exit Function
 NoLogo:
     ' Silently ignore if logo not found
-End Sub
+    InsertLogo = ""
+End Function
 
-' Ensure page breaks occur before each major table so headers repeat cleanly
+  ' Insert manual breaks only as needed and provide spacing between sections
 Private Sub ApplyTablePageBreaks(ws As Worksheet)
+    ws.ResetAllPageBreaks
     Dim lastRow As Long
     lastRow = ws.Cells(ws.Rows.Count, 2).End(xlUp).Row
-    Dim r As Long, firstTable As Boolean
-    firstTable = False
+    Dim r As Long, lastBreak As Long
+    lastBreak = 4
     For r = 4 To lastRow
         Select Case UCase$(Trim$(ws.Cells(r, 2).Value))
             Case "HOTEL", "MANAGER", "MARKET"
-                If firstTable Then
+                ' add a little space before each table header
+                If r > 1 Then ws.Rows(r - 1).RowHeight = ws.StandardHeight * 1.5
+                ' allow multiple tables on a page; only break when ~40 rows used
+                If r - lastBreak > 40 Then
                     ws.HPageBreaks.Add Before:=ws.Rows(r)
-                Else
-                    firstTable = True
+                    lastBreak = r
                 End If
         End Select
     Next r


### PR DESCRIPTION
## Summary
- ensure snapshot calculations complete before PDF export
- keep header logo until after export so header appears on all pages
- relax page breaks to allow multiple tables per page and add spacing before tables

## Testing
- `rg -n "Kill tmpPath" PdfReportModule.bas`
- `rg -n "HPageBreaks.Add" PdfReportModule.bas`


------
https://chatgpt.com/codex/tasks/task_e_68a8c32851a0832395e494b81da609b0