### PR TITLE
Ensure Input sheet creates snapshot and PDF buttons

### DIFF
--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -1638,60 +1638,57 @@ Public Sub AutoSetupOnOpen()
     EnsureNamesForInput
 End Sub
 
+Private Sub EnsureInputButtons(ws As Worksheet)
+    Dim btn As Shape
+
+    ' Snapshot generation button
+    On Error Resume Next
+    Set btn = ws.Shapes("btnBuildSnapshot")
+    On Error GoTo 0
+    If btn Is Nothing Then
+        Set btn = ws.Shapes.AddFormControl( _
+            Type:=xlButtonControl, _
+            Left:=ws.Range("D1").Left, _
+            Top:=ws.Range("D1").Top, _
+            Width:=140, Height:=28)
+        btn.Name = "btnBuildSnapshot"
+    End If
+    With btn
+        .OnAction = "BuildFormatRun"
+        .TextFrame.Characters.Text = "Generate Snapshot"
+        .TextFrame.Characters.Font.Size = 11
+        .Placement = xlMove
+    End With
+
+    ' PDF export button
+    On Error Resume Next
+    Set btn = ws.Shapes("btnExportSnapshotPDF")
+    On Error GoTo 0
+    If btn Is Nothing Then
+        Set btn = ws.Shapes.AddFormControl( _
+            Type:=xlButtonControl, _
+            Left:=ws.Range("D2").Left, _
+            Top:=ws.Range("D2").Top, _
+            Width:=140, Height:=28)
+        btn.Name = "btnExportSnapshotPDF"
+    End If
+    With btn
+        .OnAction = "BuildSnapshotReportPDF"
+        .TextFrame.Characters.Text = "Export Snapshot PDF"
+        .TextFrame.Characters.Font.Size = 11
+        .Placement = xlMove
+    End With
+End Sub
+
 Private Sub EnsureInputSheet()
     Const SH_INPUT As String = "Input"
     Dim ws As Worksheet
-     Dim btn As Shape
 
     If SheetExists(SH_INPUT) Then
         ' Sheet already exists: do NOT recreate or clear.
         Set ws = Worksheets(SH_INPUT)
 
-        ' Ensure the snapshot build button exists and is wired up
-
-        On Error Resume Next
-        Set btn = ws.Shapes("btnBuildSnapshot")
-        On Error GoTo 0
-
-        If btn Is Nothing Then
-            ' Create it once, as a Form Control button (returns Shape)
-            Set btn = ws.Shapes.AddFormControl( _
-                        Type:=xlButtonControl, _
-                        Left:=ws.Range("D1").Left, _
-                        Top:=ws.Range("D1").Top, _
-                        Width:=140, Height:=28)
-            btn.Name = "btnBuildSnapshot"
-        End If
-
-        ' Wire caption + macro every time (idempotent)
-        With btn
-            .OnAction = "BuildFormatRun"
-            .TextFrame.Characters.Text = "Build Snapshot"
-            .TextFrame.Characters.Font.Size = 11
-            .Placement = xlMove
-        End With
-
-        ' Ensure the PDF export button exists and is wired up
-        On Error Resume Next
-        Set btn = ws.Shapes("btnExportSnapshotPDF")
-        On Error GoTo 0
-
-        If btn Is Nothing Then
-            Set btn = ws.Shapes.AddFormControl( _
-                        Type:=xlButtonControl, _
-                        Left:=ws.Range("D2").Left, _
-                        Top:=ws.Range("D2").Top, _
-                        Width:=140, Height:=28)
-            btn.Name = "btnExportSnapshotPDF"
-        End If
-
-        With btn
-            .OnAction = "BuildSnapshotReportPDF"
-            .TextFrame.Characters.Text = "Export Snapshot PDF"
-            .TextFrame.Characters.Font.Size = 11
-            .Placement = xlMove
-        End With
-
+        EnsureInputButtons ws
         ws.Visible = xlSheetVisible
         Exit Sub
     End If
@@ -1720,36 +1717,8 @@ Private Sub EnsureInputSheet()
         .Columns("A").ColumnWidth = 18
         .Columns("B").ColumnWidth = 16
         .Range("A1:A2").Font.Bold = True
-
-        ' Create the build button ONCE as a Shape Form Control
-
-        Set btn = .Shapes.AddFormControl( _
-                    Type:=xlButtonControl, _
-                    Left:=.Range("D1").Left, _
-                    Top:=.Range("D1").Top, _
-                    Width:=140, Height:=28)
-        With btn
-            .Name = "btnBuildSnapshot"
-            .OnAction = "BuildFormatRun"
-            .TextFrame.Characters.Text = "Build Snapshot"
-            .TextFrame.Characters.Font.Size = 11
-            .Placement = xlMove
-        End With
-
-        ' Second button to export PDF report
-        Set btn = .Shapes.AddFormControl( _
-                    Type:=xlButtonControl, _
-                    Left:=.Range("D2").Left, _
-                    Top:=.Range("D2").Top, _
-                    Width:=140, Height:=28)
-        With btn
-            .Name = "btnExportSnapshotPDF"
-            .OnAction = "BuildSnapshotReportPDF"
-            .TextFrame.Characters.Text = "Export Snapshot PDF"
-            .TextFrame.Characters.Font.Size = 11
-            .Placement = xlMove
-        End With
     End With
+    EnsureInputButtons ws
 End Sub
 
 
@@ -1946,7 +1915,7 @@ Public Sub HardResetSnapshotConfig()
     EnsureInputSheet
     EnsureNamesForInput
 
-    MsgBox "Reset complete. Now click 'Build Snapshot' on the Input sheet.", vbInformation
+    MsgBox "Reset complete. Now click 'Generate Snapshot' on the Input sheet.", vbInformation
 End Sub
 
 Private Sub RemoveLegacySnapshotInputs()


### PR DESCRIPTION
## Summary
- Factor out snapshot/PDF button creation into `EnsureInputButtons`
- Automatically create "Generate Snapshot" and "Export Snapshot PDF" buttons on Input sheet
- Update reset message to reference new button label

## Testing
- `ls -1`

------
https://chatgpt.com/codex/tasks/task_e_68a8c6c62a0c83239772a0140f578f2c