### PR TITLE
Fix PDF header border and tighten STR table spacing

### DIFF
--- a/PdfReportModule.bas
+++ b/PdfReportModule.bas
@@ -76,7 +76,10 @@ Private Sub ApplyTablePageBreaks(ws As Worksheet)
         Select Case UCase$(Trim$(ws.Cells(r, 2).Value))
             Case "HOTEL", "MANAGER", "MARKET"
                 ' add a little space before each table header
-                If r > 1 Then ws.Rows(r - 1).RowHeight = ws.StandardHeight * 1.5
+                If r > 1 Then
+                    ws.Rows(r - 1).RowHeight = ws.StandardHeight
+                    ws.Rows(r - 1).Borders.LineStyle = xlLineStyleNone
+                End If
                 ' allow multiple tables on a page; only break when ~40 rows used
                 If r - lastBreak > 40 Then
                     ws.HPageBreaks.Add Before:=ws.Rows(r)

--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -629,9 +629,9 @@ Public Sub BuildSnapshot()
     rowPtr = BuildOneTable(wsSnap, fundDict, funds, rowPtr, "FY")
     rowPtr = rowPtr + 2
     rowPtr = BuildStrFundTable(wsSnap, fundDict, funds, rowPtr)
-    rowPtr = rowPtr + 2
+    rowPtr = rowPtr + 1
     rowPtr = BuildStrManagerTable(wsSnap, mgrs, rowPtr)
-    rowPtr = rowPtr + 2
+    rowPtr = rowPtr + 1
     rowPtr = BuildStrMarketTable(wsSnap, markets, rowPtr)
     
 ' Format overall sheet (no .Select calls)
@@ -1862,7 +1862,19 @@ Private Sub FormatSnapshotShell()
         .Font.Color = vbWhite
         .Font.Bold = True
         .RowHeight = 32
-        .BorderAround Weight:=xlThick
+        With .Borders(xlEdgeTop)
+            .LineStyle = xlContinuous
+            .Weight = xlThick
+        End With
+        With .Borders(xlEdgeLeft)
+            .LineStyle = xlContinuous
+            .Weight = xlThick
+        End With
+        With .Borders(xlEdgeRight)
+            .LineStyle = xlContinuous
+            .Weight = xlThick
+        End With
+        .Borders(xlEdgeBottom).LineStyle = xlLineStyleNone
     End With
 
     ' Pull Month/Year from names on Input sheet


### PR DESCRIPTION
## Summary
- Remove bottom border from Snapshot header to avoid line above first table
- Set table spacing rows to standard height without borders during PDF export
- Use single blank row between STR tables

## Testing
- `echo 'no tests provided'`


------
https://chatgpt.com/codex/tasks/task_e_68a8d29841f48323ac3f6f999754462b