### PR TITLE
Add thick border to snapshot header

### DIFF
--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -1744,7 +1744,10 @@ Private Sub FormatSnapshotShell()
             .LineStyle = xlContinuous
             .Weight = xlThick
         End With
-        .Borders(xlEdgeBottom).LineStyle = xlLineStyleNone
+        With .Borders(xlEdgeBottom)
+            .LineStyle = xlContinuous
+            .Weight = xlThick
+        End With
     End With
 
     ' Pull Month/Year from names on Input sheet


### PR DESCRIPTION
## Summary
- Ensure top snapshot header row uses thick border on all edges so "As of" and "Created" fields are fully enclosed

## Testing
- `echo 'No tests in this repository'`


------
https://chatgpt.com/codex/tasks/task_e_68c09a28c9b483238b800e120e834491