### PR TITLE
refactor: reuse snapshot helpers

### DIFF
--- a/CashForecastVariance.bas
+++ b/CashForecastVariance.bas
@@ -141,63 +141,6 @@ Private Function GetHotelList() As Collection
     Set GetHotelList = col
 End Function
 
-' ==== Helpers copied from Snapshot module ====
-
-Private Function SpillOrRegion(ws As Worksheet) As Range
-    On Error Resume Next
-    Set SpillOrRegion = ws.Range("A1#")
-    If SpillOrRegion Is Nothing Then
-        On Error GoTo 0
-        Set SpillOrRegion = ws.Range("A1").CurrentRegion
-    End If
-End Function
-
-Private Function FindHeaderCol(rng As Range, headerText As String) As Long
-    Dim c As Range
-    For Each c In rng.Rows(1).Cells
-        If Trim$(LCase$(c.Value)) = Trim$(LCase$(headerText)) Then
-            FindHeaderCol = c.Column - rng.Column + 1
-            Exit Function
-        End If
-    Next
-    FindHeaderCol = 0
-End Function
-
-Private Function Nz(v As Variant, Optional dflt As String = "") As String
-    If IsError(v) Then
-        Nz = dflt
-        Exit Function
-    End If
-    On Error GoTo Clean
-    Nz = Trim$(CStr(v))
-    If Len(Nz) = 0 Then Nz = dflt
-    Exit Function
-Clean:
-    Nz = dflt
-End Function
-
-Private Function SheetExists(name As String) As Boolean
-    On Error Resume Next
-    SheetExists = Not Worksheets(name) Is Nothing
-    On Error GoTo 0
-End Function
-
-Private Function SanitizeName(s As String) As String
-    Dim t As String
-    Dim i As Long, ch As String
-    For i = 1 To Len(s)
-        ch = Mid$(s, i, 1)
-        If ch Like "[A-Za-z0-9_]" Then
-            t = t & ch
-        Else
-            t = t & "_"
-        End If
-    Next i
-    If Len(t) = 0 Then t = "NA"
-    If Not (Left$(t, 1) Like "[A-Za-z_]") Then t = "_" & t
-    SanitizeName = t
-End Function
-
 Private Sub EnsureCfvInputSheet()
     Dim ws As Worksheet
     If Not SheetExists(SH_INPUT) Then
@@ -326,22 +269,5 @@ Private Sub EnsureUsaliMap()
 
     AddOrReplaceName NAME_USALI_DISPLAY, wsMap.Range("A:A")
     AddOrReplaceName NAME_USALI_CODE, wsMap.Range("B:B")
-End Sub
-
-Private Sub AddOrReplaceName(nm As String, tgt As Range)
-    KillAllSheetScoped nm
-    On Error Resume Next
-    ThisWorkbook.Names(nm).Delete
-    On Error GoTo 0
-    ThisWorkbook.Names.Add Name:=nm, RefersTo:=tgt
-End Sub
-
-Private Sub KillAllSheetScoped(ByVal nm As String)
-    Dim sh As Worksheet
-    For Each sh In ThisWorkbook.Worksheets
-        On Error Resume Next
-        sh.Names(nm).Delete
-        On Error GoTo 0
-    Next sh
 End Sub
 

--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -1352,7 +1352,7 @@ Private Sub AddMonthValidation(tgt As Range)
     End With
 End Sub
 
-Private Function SpillOrRegion(ws As Worksheet) As Range
+Public Function SpillOrRegion(ws As Worksheet) As Range
     On Error Resume Next
     Set SpillOrRegion = ws.Range("A1#")
     If SpillOrRegion Is Nothing Then
@@ -1361,7 +1361,7 @@ Private Function SpillOrRegion(ws As Worksheet) As Range
     End If
 End Function
 
-Private Function FindHeaderCol(rng As Range, headerText As String) As Long
+Public Function FindHeaderCol(rng As Range, headerText As String) As Long
     Dim c As Range
     For Each c In rng.Rows(1).Cells
         If Trim$(LCase$(c.Value)) = Trim$(LCase$(headerText)) Then
@@ -1381,13 +1381,13 @@ End Sub
 
 ' ============== Utilities ==============
 
-Private Function SheetExists(name As String) As Boolean
+Public Function SheetExists(name As String) As Boolean
     On Error Resume Next
     SheetExists = Not Worksheets(name) Is Nothing
     On Error GoTo 0
 End Function
 
-Private Sub AddOrReplaceName(nm As String, tgt As Range)
+Public Sub AddOrReplaceName(nm As String, tgt As Range)
    
     ' Remove any sheet-scoped duplicates everywhere
     KillAllSheetScoped nm
@@ -1398,7 +1398,7 @@ Private Sub AddOrReplaceName(nm As String, tgt As Range)
 End Sub
 
 
-Private Function SanitizeName(s As String) As String
+Public Function SanitizeName(s As String) As String
     Dim t As String
     Dim i As Long, ch As String
 
@@ -1419,7 +1419,7 @@ Private Function SanitizeName(s As String) As String
     SanitizeName = t
 End Function
 
-Private Function Nz(v As Variant, Optional dflt As String = "") As String
+Public Function Nz(v As Variant, Optional dflt As String = "") As String
     If IsError(v) Then
         Nz = dflt
         Exit Function
@@ -1593,7 +1593,7 @@ Private Sub EnsureNamesForInput()
     ThisWorkbook.Names.Add Name:="MonthNum", _
         RefersTo:="=MATCH(Input!B1,{""January"",""February"",""March"",""April"",""May"",""June"",""July"",""August"",""September"",""October"",""November"",""December""},0)"
 End Sub
-Private Sub KillAllSheetScoped(ByVal nm As String)
+Public Sub KillAllSheetScoped(ByVal nm As String)
     Dim sh As Worksheet
     For Each sh In ThisWorkbook.Worksheets
         On Error Resume Next


### PR DESCRIPTION
## Summary
- expose shared helper utilities in SnapshotModule for workbook-wide reuse
- remove duplicate helper implementations from CashForecastVariance

## Testing
- `rg -n "Function SpillOrRegion" CashForecastVariance.bas`
- `rg -n "Public Function SpillOrRegion" SnapshotModule.bas`


------
https://chatgpt.com/codex/tasks/task_e_68c1b7caca008323bdd5410f946a4300