### PR TITLE
Fix Total Year label in Cash Forecast Variance

### DIFF
--- a/CashForecastVariance.bas
+++ b/CashForecastVariance.bas
@@ -35,7 +35,7 @@ Public Sub BuildCashForecastVariance()
     monthName = Nz(Range(NAME_CFV_MONTH).Value)
     Dim timeAgg As String
     If StrComp(monthName, "Total Year", vbTextCompare) = 0 Then
-        timeAgg = "Year"
+        timeAgg = "Total Year"
     Else
         timeAgg = "Month"
     End If


### PR DESCRIPTION
## Summary
- Display "Total Year" in Cash Forecast Variance templates when Total Year is selected for the time aggregation

## Testing
- `pre-commit run --files CashForecastVariance.bas` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ee62d3cc832381673129c9ab0e44