### PR TITLE
Save snapshot and CFV PDFs to dated folders

### DIFF
--- a/CashForecastVariancePdf.bas
+++ b/CashForecastVariancePdf.bas
@@ -24,11 +24,29 @@ Public Sub BuildCashForecastVariancePDF()
         arr(i) = cfvSheets(i).Name
         ApplyCfvPageSetup cfvSheets(i)
     Next i
-    
+    Dim firstSheet As Worksheet
+    Set firstSheet = cfvSheets(1)
+    Dim yr As Long, mo As Long
+    Dim monthName As String
+    On Error Resume Next
+    yr = CLng(firstSheet.Range("RYear_YYYY").Value)
+    monthName = CStr(firstSheet.Range("Month_MMMM").Value)
+    On Error GoTo 0
+    If Len(monthName) > 0 Then mo = Month(DateValue("1 " & monthName & " " & yr))
+    Dim prefix As String
+    If yr > 0 And mo > 0 Then
+        prefix = Format(DateSerial(yr, mo, 1), "mmYY")
+    Else
+        prefix = Format(Now, "mmYY")
+    End If
+
+    Dim folderPath As String
+    folderPath = ThisWorkbook.Path & Application.PathSeparator & "CashForecastVariance"
+    If Dir(folderPath, vbDirectory) = "" Then MkDir folderPath
+
     Dim pdfPath As String
-    pdfPath = ThisWorkbook.Path & Application.PathSeparator & _
-              "CashForecastVariance_" & Format(Now, "yyyymmdd_hhnn") & ".pdf"
-    
+    pdfPath = folderPath & Application.PathSeparator & prefix & "_CashForecastVariance.pdf"
+
     Dim prevSheet As Worksheet
     Set prevSheet = ActiveSheet
     ThisWorkbook.Sheets(arr).Select

--- a/PdfReportModule.bas
+++ b/PdfReportModule.bas
@@ -16,9 +16,24 @@ Public Sub BuildSnapshotReportPDF()
     ApplyTablePageBreaks ws
     DoEvents
 
+    Dim yr As Long, mo As Long
+    On Error Resume Next
+    yr = CLng(ThisWorkbook.Names("Snap_YearNum").RefersToRange.Value)
+    mo = CLng(ThisWorkbook.Names("Snap_MonthNum").RefersToRange.Value)
+    On Error GoTo 0
+    Dim prefix As String
+    If yr > 0 And mo > 0 Then
+        prefix = Format(DateSerial(yr, mo, 1), "mmYY")
+    Else
+        prefix = Format(Now, "mmYY")
+    End If
+
+    Dim folderPath As String
+    folderPath = ThisWorkbook.Path & Application.PathSeparator & "Snapshot"
+    If Dir(folderPath, vbDirectory) = "" Then MkDir folderPath
+
     Dim pdfPath As String
-    pdfPath = ThisWorkbook.Path & Application.PathSeparator & _
-              "SnapshotReport_" & Format(Now, "yyyymmdd_hhnn") & ".pdf"
+    pdfPath = folderPath & Application.PathSeparator & prefix & "_Snapshot.pdf"
     ws.ExportAsFixedFormat Type:=xlTypePDF, Filename:=pdfPath, _
                             Quality:=xlQualityStandard, _
                             IncludeDocProperties:=True, _


### PR DESCRIPTION
## Summary
- Save snapshot reports to a Snapshot folder with MMYY-based filename
- Save cash forecast variance PDFs to a CashForecastVariance folder with MMYY-based filename

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8ed0d888323af36afe97e83701c