### PR TITLE
Map NOI metric to EBITDA less reserves

### DIFF
--- a/CashForecastVariance.bas
+++ b/CashForecastVariance.bas
@@ -287,7 +287,7 @@ Private Sub EnsureUsaliMap()
         Array("ADR", "ADR", "Total ADR - 100"), _
         Array("RevPAR", "RevPAR", "RevPAR - 100"), _
         Array("Total Rev (000's)", "Total Rev", "Total Revenue - 000"), _
-        Array("NOI (000's)", "NOI", "Total Net Operating Income - 000"), _
+        Array("NOI (000's)", "NOI", "Total EBITDA Less Reserves - 000"), _
         Array("NOI Margin", "NOI Margin", "Total Net Operating Income % - 000"), _
         Array("GOP (000's)", "GOP", "Total Hotel GOP - 000"), _
         Array("GOP Margin", "GOP Margin", "Total Hotel GOP % - 000"), _

--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -1266,7 +1266,7 @@ Private Sub EnsureUsaliMap()
         Array("ADR", "ADR", "Total ADR - 100"), _
         Array("RevPAR", "RevPAR", "RevPAR - 100"), _
         Array("Total Rev (000's)", "Total Rev", "Total Revenue - 000"), _
-        Array("NOI (000's)", "NOI", "Total Net Operating Income - 000"), _
+        Array("NOI (000's)", "NOI", "Total EBITDA Less Reserves - 000"), _
         Array("NOI Margin", "NOI Margin", "Total Net Operating Income % - 000"), _
         Array("GOP (000's)", "GOP", "Total Hotel GOP - 000"), _
         Array("GOP Margin", "GOP Margin", "Total Hotel GOP % - 000"), _


### PR DESCRIPTION
## Summary
- Map "NOI (000's)" display metric to USALI "Total EBITDA Less Reserves - 000"
- Update Cash Forecast Variance mapping accordingly

## Testing
- `rg -F "Total EBITDA Less Reserves - 000" -n`


------
https://chatgpt.com/codex/tasks/task_e_68c2e8b8239083239ddbad29c6d39c18