### PR TITLE
Map occupancy metric to Total Rooms Sold USALI code

### DIFF
--- a/CashForecastVariance.bas
+++ b/CashForecastVariance.bas
@@ -283,7 +283,7 @@ Private Sub EnsureUsaliMap()
 
     Dim pairs As Variant
     pairs = Array( _
-        Array("Occ", "Occ", "Total Occ % - 100"), _
+        Array("Occ", "Occ", "Total Rooms Sold - 100"), _
         Array("ADR", "ADR", "Total ADR - 100"), _
         Array("RevPAR", "RevPAR", "RevPAR - 100"), _
         Array("Total Rev (000's)", "Total Rev", "Total Revenue - 000"), _

--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -1262,7 +1262,7 @@ Private Sub EnsureUsaliMap()
     ' You can add/remove lines here later; the code below will keep only those that exist.
     Dim pairs As Variant
     pairs = Array( _
-        Array("Occ", "Occ", "Total Occ % - 100"), _
+        Array("Occ", "Occ", "Total Rooms Sold - 100"), _
         Array("ADR", "ADR", "Total ADR - 100"), _
         Array("RevPAR", "RevPAR", "RevPAR - 100"), _
         Array("Total Rev (000's)", "Total Rev", "Total Revenue - 000"), _


### PR DESCRIPTION
## Summary
- Map "Occ" metric to tenant USALI string "Total Rooms Sold - 100" in Snapshot module
- Align Cash Forecast Variance USALI map with same occupancy mapping

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2e9db81e88323b273df6c3ec817fb