### PR TITLE
Map occupancy to Paid Occ % USALI code

### DIFF
--- a/CashForecastVariance.bas
+++ b/CashForecastVariance.bas
@@ -283,7 +283,7 @@ Private Sub EnsureUsaliMap()
 
     Dim pairs As Variant
     pairs = Array( _
-        Array("Occ", "Occ", "Total Rooms Sold - 100"), _
+        Array("Occ", "Occ", "Paid Occ % - 100"), _
         Array("ADR", "ADR", "Total ADR - 100"), _
         Array("RevPAR", "RevPAR", "RevPAR - 100"), _
         Array("Total Rev (000's)", "Total Rev", "Total Revenue - 000"), _

--- a/SnapshotModule.bas
+++ b/SnapshotModule.bas
@@ -1262,7 +1262,7 @@ Private Sub EnsureUsaliMap()
     ' You can add/remove lines here later; the code below will keep only those that exist.
     Dim pairs As Variant
     pairs = Array( _
-        Array("Occ", "Occ", "Total Rooms Sold - 100"), _
+        Array("Occ", "Occ", "Paid Occ % - 100"), _
         Array("ADR", "ADR", "Total ADR - 100"), _
         Array("RevPAR", "RevPAR", "RevPAR - 100"), _
         Array("Total Rev (000's)", "Total Rev", "Total Revenue - 000"), _


### PR DESCRIPTION
## Summary
- Map occupancy metrics in Snapshot and CFV to the 'Paid Occ % - 100' USALI code

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c2eb40a8508323a6e8c9058cf1f5d7